### PR TITLE
修改Maven仓库地址及kaptcha的Maven包

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 		<repository>
 			<id>nexus</id>
 			<name>local private nexus</name>
-			<url>http://maven.oschina.net/content/groups/public/</url>
+			<url>http://maven.aliyun.com/nexus/content/groups/public/</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>
@@ -415,11 +415,16 @@
         </dependency>
         
 		<!-- 谷歌验证码 -->
-		<dependency>
-			<groupId>com.google.code</groupId>
-			<artifactId>kaptcha</artifactId>
-			<version>2.3.2</version>
-		</dependency>
+		<!--<dependency>-->
+			<!--<groupId>com.google.code</groupId>-->
+			<!--<artifactId>kaptcha</artifactId>-->
+			<!--<version>2.3.2</version>-->
+		<!--</dependency>-->
+        <dependency>
+            <groupId>com.github.penggle</groupId>
+            <artifactId>kaptcha</artifactId>
+            <version>2.3.2</version>
+        </dependency>
 
 		<!-- HTML解析相关 -->
 		<dependency>


### PR DESCRIPTION
oschina的Maven仓库由于种种原因无法访问，建议修改成aliyun的Maven仓库。

最新的kaptcha的Maven包已由

```
<dependency>
    <groupId>com.google.code</groupId>
    <artifactId>kaptcha</artifactId>
    <version>2.3.2</version>
</dependency>
```

修改为：

```
<dependency>
    <groupId>com.github.penggle</groupId>
    <artifactId>kaptcha</artifactId>
    <version>2.3.2</version>
</dependency>
```
